### PR TITLE
use image digest for update-base target

### DIFF
--- a/make/images.mk
+++ b/make/images.mk
@@ -5,7 +5,7 @@ update-base:
 		--volume $(PWD)/images/stack-base/files/usr/local/bin/:/usr/local/bin/ \
 		--volume $(PWD)/images/stack-base/files/etc/apt/packages.list:/etc/apt/packages.list \
 		--volume $(PWD)/images/stack-base/files/etc/apt/sources.list:/etc/apt/sources.list \
-		debian:buster \
+		debian:buster@sha256:$(DEBIAN_IMAGE_HASH) \
 		/usr/local/bin/update-packages
 
 images/stack-base.tar: images/stack-base


### PR DESCRIPTION
It seems like a best practice to use the image digest for locking the
docker image that is used to update the stack-base image